### PR TITLE
Automatic canvas/page height resizing

### DIFF
--- a/src/main/java/edu/mit/blocks/workspace/BlockCanvas.java
+++ b/src/main/java/edu/mit/blocks/workspace/BlockCanvas.java
@@ -411,8 +411,13 @@ public class BlockCanvas implements PageChangeListener, ISupportMemento {
      */
     public void reformBlockCanvas() {
         int widthCounter = 0;
+        int maxHeight = 0;
         for (int i = 0; i < pages.size(); i++) {
             Page p = pages.get(i);
+            // compute maximum overall page height.
+            if (p.getMinimumPixelHeight()>maxHeight) {
+                maxHeight = p.getMinimumPixelHeight();
+            }
             if (p.getDefaultPageColor() == null) {
                 if (i % 2 == 1) {
                     p.setPageColor(new Color(30, 30, 30));
@@ -431,7 +436,7 @@ public class BlockCanvas implements PageChangeListener, ISupportMemento {
                     5,
                     d.getLeftPage().getJComponent().getHeight());
         }
-        canvas.setPreferredSize(new Dimension(widthCounter, (int) (Page.DEFAULT_ABSTRACT_HEIGHT * Page.getZoomLevel())));
+        canvas.setPreferredSize(new Dimension(widthCounter, (int) (maxHeight * Page.getZoomLevel())));
         scrollPane.revalidate();
         scrollPane.repaint();
     }

--- a/src/main/java/edu/mit/blocks/workspace/Page.java
+++ b/src/main/java/edu/mit/blocks/workspace/Page.java
@@ -95,6 +95,8 @@ public class Page implements WorkspaceWidget, SearchableContainer, ISupportMemen
     private static final int COLLAPSED_WIDTH = 20;
     /** The smallest value that this.minimumPixelWidth/zoom can be */
     private static final int DEFAULT_MINUMUM_WIDTH = 100;
+    /** The smallest value that this.minimumPixelHeight/zoom can be */
+    private static final int DEFAULT_MINIMUM_HEIGHT = 100;
     /** The default abstract width */
     private static final int DEFAULT_ABSTRACT_WIDTH = 700;
     /** The default abstract height */
@@ -117,6 +119,8 @@ public class Page implements WorkspaceWidget, SearchableContainer, ISupportMemen
     private boolean mouseIsInPage = false;
     /** The minimum width of the page in pixels */
     private int minimumPixelWidth = 0;
+    /** The minimum height of the page in pixels */
+    private int minimumPixelHeight = 0;
     /** Fullview */
     private boolean fullview;
     /** The GUI component for interfacing with the user
@@ -511,6 +515,9 @@ public class Page implements WorkspaceWidget, SearchableContainer, ISupportMemen
                 this.setPixelWidth(p.x + block.getComment().getWidth() + 1);
             }
         }
+        
+        // Recompute page height.
+        reformMinimumPixelHeight();
 
         //repaint all pages
         PageChangeEventManager.notifyListeners();
@@ -543,6 +550,25 @@ public class Page implements WorkspaceWidget, SearchableContainer, ISupportMemen
         if (this.minimumPixelWidth < Page.DEFAULT_MINUMUM_WIDTH * zoom) {
             this.minimumPixelWidth = (int) (Page.DEFAULT_MINUMUM_WIDTH * zoom);
         }
+    }
+    
+    public void reformMinimumPixelHeight() {
+        minimumPixelHeight = 0;
+        for (RenderableBlock b : this.getBlocks()) {
+            if (b.getY()+b.getHeight()+b.getHighlightStrokeWidth() /2 > minimumPixelHeight) {
+                minimumPixelHeight = b.getY() + b.getHeight() + b.getHighlightStrokeWidth()/2+1;
+            }
+            if (b.hasComment()) {
+                minimumPixelHeight = b.getComment().getY() + b.getComment().getHeight() + 1;
+            }
+        }
+        if (this.minimumPixelHeight < Page.DEFAULT_MINIMUM_HEIGHT * zoom) {
+            this.minimumPixelHeight = (int) (Page.DEFAULT_MINIMUM_HEIGHT * zoom);
+        }
+    }
+    
+    public int getMinimumPixelHeight() {
+        return this.minimumPixelHeight;
     }
 
     /**


### PR DESCRIPTION
This commit automatically resizes the page/canvas height when blocks are moved around, rather than relying on the fixed height hard-coded into the Page class. This prevents blocks from hanging off the bottom of the page, and allows a page to be resized indefinitely to fit its contents.
